### PR TITLE
Empty results fix

### DIFF
--- a/python/src/mapping_info.cpp
+++ b/python/src/mapping_info.cpp
@@ -253,7 +253,7 @@ PYBIND11_MODULE(_info, m) {
           "Returns the list of scored lattice mappings.")
       .def("__len__", &LatticeMappingResults::size)
       .def("__getitem__",
-           [](LatticeMappingResults const &m, Index i) { return m.data[i]; })
+           [](LatticeMappingResults const &m, Index i) { return m.data.at(i); })
       .def(
           "__iter__",
           [](LatticeMappingResults const &m) {
@@ -453,7 +453,7 @@ PYBIND11_MODULE(_info, m) {
           "Returns the list of scored atom mappings.")
       .def("__len__", &AtomMappingResults::size)
       .def("__getitem__",
-           [](AtomMappingResults const &m, Index i) { return m.data[i]; })
+           [](AtomMappingResults const &m, Index i) { return m.data.at(i); })
       .def(
           "__iter__",
           [](AtomMappingResults const &m) {
@@ -646,7 +646,7 @@ PYBIND11_MODULE(_info, m) {
           "Returns the list of scored structure mappings.")
       .def("__len__", &StructureMappingResults::size)
       .def("__getitem__",
-           [](StructureMappingResults const &m, Index i) { return m.data[i]; })
+           [](StructureMappingResults const &m, Index i) { return m.data.at(i); })
       .def(
           "__iter__",
           [](StructureMappingResults const &m) {

--- a/python/tests/test_info_io.py
+++ b/python/tests/test_info_io.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 import libcasm.xtal as xtal
 import libcasm.xtal.prims as xtal_prims
 import libcasm.xtal.structures as xtal_structures
@@ -7,7 +8,6 @@ import libcasm.mapping.info as info
 
 
 def test_structure_mapping_io():
-
     prim = xtal_prims.BCC(r=1.0, occ_dof=["A", "B", "Va"])
     prim_factor_group = xtal.make_factor_group(prim)
 
@@ -63,9 +63,12 @@ def test_structure_mapping_io():
     obj = info.AtomMapping.from_dict(data)
     assert isinstance(obj, info.AtomMapping)
 
+    # Do not segfault on out of bounds index
+    with pytest.raises(IndexError):
+        structure_mappings[len(structure_mappings)]
+
 
 def test_lattice_and_atom_mapping_io():
-
     prim = xtal_prims.BCC(r=1.0, occ_dof=["A", "B", "Va"])
     prim_factor_group = xtal.make_factor_group(prim)
     point_group = xtal.make_crystal_point_group(prim)
@@ -102,6 +105,10 @@ def test_lattice_and_atom_mapping_io():
     obj = info.ScoredLatticeMapping.from_dict(data)
     assert isinstance(obj, info.ScoredLatticeMapping)
 
+    # Do not segfault on out of bounds index
+    with pytest.raises(IndexError):
+        lattice_mappings[len(lattice_mappings)]
+
     atom_mappings = map_atoms(
         prim=prim,
         structure=hcp_structure,
@@ -131,3 +138,7 @@ def test_lattice_and_atom_mapping_io():
     assert isinstance(data, dict)
     obj = info.ScoredAtomMapping.from_dict(data)
     assert isinstance(obj, info.ScoredAtomMapping)
+
+    # Do not segfault on out of bounds index
+    with pytest.raises(IndexError):
+        atom_mappings[len(lattice_mappings)]


### PR DESCRIPTION
The __getitem__ method for StructureMappingResults segfaults when there is no data. Example:

```
import libcasm.mapping.methods as mapmethods                         
import libcasm.xtal.prims as xtal_prims
import libcasm.xtal as xtal
hcp = xtal_prims.HCP(r=1)
struc = xtal.Structure.from_dict({'atom_coords': [[0, 0, 0]], 'atom_type': ['H'], 'coordinate_mode': 'Cartesian', 'lattice_vectors': [[1, 0, 0], [0, 1, 0], [0, 0, 1]]})
mapping = mapmethods.map_structures(hcp, struc, max_vol=1)
mapping.data() # empty list
mapping.data()[0] # python error
mapping[0] # segfault
```

After changing [] to .at(), there is now an IndexError instead of a segfault:
```
IndexError: vector::_M_range_check: __n (which is 1) >= this->size() (which is 0)
```

Possible additional changes:
- Add a test
- Catch the error and return an empty list instead
- Look in other files for the same bug

Let me know if you want me to do any of these.