### PR TITLE
2.X fix dtype

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -45,7 +45,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          python-version: '3.11'
 
       - name: Set up requirements and configuration variables
         run: |

--- a/.github/workflows/test-linux-build.yml
+++ b/.github/workflows/test-linux-build.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          python-version: '3.11'
 
       - name: Set up requirements & configuration variables
         run: |
@@ -40,7 +40,7 @@ jobs:
         uses: actions/cache/restore@v3
         with:
           path: CASMcode_crystallography/dist
-          key: ${{ runner.os }}-libcasm-xtal-v2-0a2
+          key: ${{ runner.os }}-libcasm-xtal-v2-0a6
 
       - name: Install CASM dependencies
         run: |

--- a/.github/workflows/test-linux-cxx-only.yml
+++ b/.github/workflows/test-linux-cxx-only.yml
@@ -10,13 +10,14 @@ jobs:
     uses: ./.github/workflows/test-linux-dependencies.yml
 
   build:
+    needs: build-depends
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          python-version: '3.11'
 
       - name: Set up requirements & configuration variables
         run: |
@@ -39,7 +40,7 @@ jobs:
         uses: actions/cache/restore@v3
         with:
           path: CASMcode_crystallography/dist
-          key: ${{ runner.os }}-libcasm-xtal-v2-0a2
+          key: ${{ runner.os }}-libcasm-xtal-v2-0a6
 
       - name: Install CASM dependencies
         run: |

--- a/.github/workflows/test-linux-dependencies.yml
+++ b/.github/workflows/test-linux-dependencies.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          python-version: '3.11'
 
       - name: Set up requirements & configuration variables
         run: |
@@ -58,7 +58,7 @@ jobs:
         uses: actions/cache/restore@v3
         with:
           path: CASMcode_crystallography/dist
-          key: ${{ runner.os }}-libcasm-xtal-v2-0a2
+          key: ${{ runner.os }}-libcasm-xtal-v2-0a6
 
       - name: checkout libcasm-xtal
         if: steps.cache-libcasm-xtal-restore.outputs.cache-hit != 'true'
@@ -66,7 +66,7 @@ jobs:
         with:
           repository: prisms-center/CASMcode_crystallography
           path: CASMcode_crystallography
-          ref: v2.0a2
+          ref: v2.0a6
 
       - name: make xtal
         if: steps.cache-libcasm-xtal-restore.outputs.cache-hit != 'true'

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          python-version: '3.11'
 
       - name: Set up requirements & configuration variables
         run: |
@@ -40,7 +40,7 @@ jobs:
         uses: actions/cache/restore@v3
         with:
           path: CASMcode_crystallography/dist
-          key: ${{ runner.os }}-libcasm-xtal-v2-0a2
+          key: ${{ runner.os }}-libcasm-xtal-v2-0a6
 
       - name: Install CASM dependencies
         run: |

--- a/.github/workflows/test-macos-build.yml
+++ b/.github/workflows/test-macos-build.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          python-version: '3.11'
 
       - name: Set up requirements & configuration variables
         run: |

--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          python-version: '3.11'
 
       - name: Set up requirements & configuration variables
         run: |

--- a/build_requirements.txt
+++ b/build_requirements.txt
@@ -5,4 +5,4 @@ cmake>=3.20
 ninja
 pybind11>=2.6
 libcasm-global>=2.0.2
-libcasm-xtal>=2.0a2
+libcasm-xtal>=2.0a6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires = [
     "ninja",
     "pybind11>=2.6",
     "libcasm-global>=2.0.2",
-    "libcasm-xtal>=2.0a2",
+    "libcasm-xtal>=2.0a6",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -30,7 +30,7 @@ classifiers = [
 ]
 dependencies = [
   "libcasm-global>=2.0.2",
-  "libcasm-xtal>=2.0a2",
+  "libcasm-xtal>=2.0a6",
   "numpy",
 ]
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -5,6 +5,6 @@ requires = [
     "wheel",
     "pybind11>=2.8.0",
     "libcasm-global>=2.0.2",
-    "libcasm-xtal>=2.0a2",
+    "libcasm-xtal>=2.0a6",
 ]
 build-backend = "setuptools.build_meta"

--- a/python/tests/test_map_structures.py
+++ b/python/tests/test_map_structures.py
@@ -51,6 +51,13 @@ def make_isotropic_atom_cost(
     return isotropic_atom_cost
 
 
+def as_int(a):
+    b = np.rint(a)
+    if not np.allclose(a, b):
+        raise Exception("Error converting to integer array: not approximately integer")
+    return np.array(b, dtype=int, order="F")
+
+
 def check_mapping(prim, structure, structure_mapping):
     # print("structure:")
     # print("lattice_column_vector_matrix:\n",
@@ -75,8 +82,8 @@ def check_mapping(prim, structure, structure_mapping):
     F = lmap.deformation_gradient()
     Q = lmap.isometry()
     U = lmap.right_stretch()
-    T = lmap.transformation_matrix_to_super()
-    N = lmap.reorientation()
+    T = as_int(lmap.transformation_matrix_to_super())
+    N = as_int(lmap.reorientation())
     # print("F:\n", F)
     # print("Q:\n", Q)
     # print("U:\n", U)
@@ -97,7 +104,9 @@ def check_mapping(prim, structure, structure_mapping):
         atom_coordinate_frac=prim.coordinate_frac(),
         atom_type=[x[0] for x in prim_occ_dof],
     )
-    ideal_superstructure = xtal.make_superstructure(T @ N, prim_structure)
+
+    S = np.matmul(T, N, order="F")
+    ideal_superstructure = xtal.make_superstructure(S, prim_structure)
     amap = structure_mapping.atom_mapping()
     r1 = ideal_superstructure.atom_coordinate_cart()
     r2 = structure.atom_coordinate_cart()
@@ -187,6 +196,7 @@ def test_map_structures_2():
             [0, 0, 2],
         ],
         dtype=int,
+        order="F",
     )
     structure = xtal.make_superstructure(T, unit_structure)
 
@@ -305,7 +315,7 @@ def test_map_structures_5():
     Ui = np.array([[1.01, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]])
     Fi = Qi @ Ui
 
-    T = np.eye(3) * 2
+    T = np.eye(3, dtype=int, order="F") * 2
     prim_structure = xtal.Structure(
         lattice=prim.lattice(),
         atom_coordinate_frac=prim.coordinate_frac(),

--- a/python/tests/test_map_structures.py
+++ b/python/tests/test_map_structures.py
@@ -55,7 +55,7 @@ def as_int(a):
     b = np.rint(a)
     if not np.allclose(a, b):
         raise Exception("Error converting to integer array: not approximately integer")
-    return np.array(b, dtype=int, order="F")
+    return np.array(b, dtype=int)
 
 
 def check_mapping(prim, structure, structure_mapping):
@@ -105,8 +105,7 @@ def check_mapping(prim, structure, structure_mapping):
         atom_type=[x[0] for x in prim_occ_dof],
     )
 
-    S = np.matmul(T, N, order="F")
-    ideal_superstructure = xtal.make_superstructure(S, prim_structure)
+    ideal_superstructure = xtal.make_superstructure(T @ N, prim_structure)
     amap = structure_mapping.atom_mapping()
     r1 = ideal_superstructure.atom_coordinate_cart()
     r2 = structure.atom_coordinate_cart()
@@ -196,7 +195,6 @@ def test_map_structures_2():
             [0, 0, 2],
         ],
         dtype=int,
-        order="F",
     )
     structure = xtal.make_superstructure(T, unit_structure)
 
@@ -315,7 +313,7 @@ def test_map_structures_5():
     Ui = np.array([[1.01, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]])
     Fi = Qi @ Ui
 
-    T = np.eye(3, dtype=int, order="F") * 2
+    T = np.eye(3, dtype=int) * 2
     prim_structure = xtal.Structure(
         lattice=prim.lattice(),
         atom_coordinate_frac=prim.coordinate_frac(),


### PR DESCRIPTION
- Update tests to use stricter libcasm.xtal integer array parameter type
- Set python testing version to 3.11
- Set libcasm-xtal>=2.0a6