### PR TITLE
Documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The libcasm-mapping package is the CASM structure mapping module. This includes:
 
 #### Usage
 
-See the [libcasm-mapping docs](todo).
+See the [libcasm docs](https://prisms-center.github.io/CASMcode_pydocs/libcasm/overview/latest/).
 
 
 #### About CASM


### PR DESCRIPTION
Not sure if the link is supposed to go directly to libcasm mapping docs or to the general docs.