### PR TITLE
make_mapped_structure local properties fix

### DIFF
--- a/python/tests/test_map_structures.py
+++ b/python/tests/test_map_structures.py
@@ -1,4 +1,5 @@
 """Test structure mapping"""
+
 import math
 
 import numpy as np
@@ -468,7 +469,7 @@ def test_make_mapped_structure_0(shared_datadir):
             prim=xtal_prim, lattice_mapping=lattice_mapping, atom_mapping=i
         )
 
-    print(structure_mapping.to_dict())
+    # print(structure_mapping.to_dict())
 
     # attempt to make the mapped structure
     mapped_structure = mapmethods.make_mapped_structure(
@@ -477,3 +478,9 @@ def test_make_mapped_structure_0(shared_datadir):
     )
 
     assert isinstance(mapped_structure, xtal.Structure)
+
+    # make sure the forces in the mapped_structure are non-zero
+    assert not np.allclose(
+        np.zeros(mapped_structure.atom_properties()["force"].shape),
+        mapped_structure.atom_properties()["force"],
+    )

--- a/src/casm/mapping/StructureMapping.cc
+++ b/src/casm/mapping/StructureMapping.cc
@@ -165,7 +165,7 @@ xtal::SimpleStructure make_mapped_structure(
     std::string key = pair.first;
     Eigen::MatrixXd const &q2 = pair.second;
     Eigen::MatrixXd q2_with_Va = Eigen::MatrixXd::Zero(q2.rows(), n_sites);
-    q2_with_Va.block(0, q2.rows(), 0, q2.cols()) = q2;
+    q2_with_Va.block(0, 0, q2.rows(), q2.cols()) = q2;
     try {
       AnisoValTraits traits(key);
       Eigen::MatrixXd M = traits.symop_to_matrix(


### PR DESCRIPTION
- Fixed a bug in `make_mapped_structure()` which was always returning zero for atom properties 
- Added a check in python tests to ensure the local properties are being computed correctly